### PR TITLE
Removing the include Statement declarations

### DIFF
--- a/lib/statement.rb
+++ b/lib/statement.rb
@@ -2,7 +2,6 @@ require "statement/version"
 require "statement/feed"
 require "statement/scraper"
 require "statement/utils"
-include Statement
 
 module Statement
   extend Utils

--- a/lib/statement/feed.rb
+++ b/lib/statement/feed.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'open-uri'
 require 'american_date'
 require 'nokogiri'
-include Statement
 
 module Statement
   class Feed


### PR DESCRIPTION
Sorry to bother, but I don't think you need them there actually. Sadly, they're causing an issue for Hoover because I also have a class named Feed, so there's a name collision here caused by the `include Statement` declarations
